### PR TITLE
fix: Redirect to login when token expires

### DIFF
--- a/src/app/modules/core/services/interceptors/loader-http-inteceptor.service.ts
+++ b/src/app/modules/core/services/interceptors/loader-http-inteceptor.service.ts
@@ -1,19 +1,29 @@
 import { Injectable } from '@angular/core';
-import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent, HttpErrorResponse } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
 import { LoaderService } from '../loader/loader.service';
-import { finalize } from 'rxjs/operators';
+import { catchError, finalize } from 'rxjs/operators';
+import { JwtHelperService } from '@auth0/angular-jwt';
+import { Router } from '@angular/router';
+import { AuthService } from '../auth/auth.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class LoaderHttpInteceptorService implements HttpInterceptor {
 
-  constructor(private loaderService: LoaderService) { }
+  constructor(private loaderService: LoaderService, private jwtHelperService: JwtHelperService, private router: Router, private authService: AuthService) { }
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     this.loaderService.showLoader();
-    return next.handle(req).pipe(finalize(() => this.loaderService.hideLoader()));
+
+    return next.handle(req).pipe(catchError((e: HttpErrorResponse) => {
+      if (e.status === 401) {
+        this.authService.logoutUser();
+        this.router.navigateByUrl('/login');
+      }
+      return Observable.throw(e);
+    }), finalize(() => this.loaderService.hideLoader()));
   }
 
 }

--- a/src/app/modules/post/components/post/post.component.ts
+++ b/src/app/modules/post/components/post/post.component.ts
@@ -25,10 +25,9 @@ export class PostComponent implements OnInit {
     post_id: -1
   };
   userId: number;
-  private helper = new JwtHelperService();
 
-  constructor(private router: Router, private activatedRoute: ActivatedRoute, private postsService: PostsService) {
-    this.userId = this.helper.decodeToken(localStorage.getItem('access_token')).Id;
+  constructor(private router: Router, private activatedRoute: ActivatedRoute, private postsService: PostsService, private jwtHelper: JwtHelperService) {
+    this.userId = !this.jwtHelper.isTokenExpired() ? this.jwtHelper.decodeToken(localStorage.getItem('access_token')).Id : undefined;
    }
 
   ngOnInit() {


### PR DESCRIPTION
Redirect to login when token expires

* Check in the http interceptor if the token has expired and if so then redirect to login
* Get the JwtHelper using dependency injection